### PR TITLE
Querysets do not always return in same order

### DIFF
--- a/rest_framework_json_api/exceptions.py
+++ b/rest_framework_json_api/exceptions.py
@@ -2,12 +2,18 @@ import inspect
 from django.utils import six, encoding
 from django.utils.translation import ugettext_lazy as _
 from rest_framework import status, exceptions
-from rest_framework.views import exception_handler as drf_exception_handler
 
 from rest_framework_json_api.utils import format_value
 
 
 def exception_handler(exc, context):
+    # Import this here to avoid potential edge-case circular imports, which
+    # crashes with:
+    # "ImportError: Could not import 'rest_framework_json_api.parsers.JSONParser' for API setting
+    # 'DEFAULT_PARSER_CLASSES'. ImportError: cannot import name 'exceptions'.'"
+    #
+    # Also see: https://github.com/django-json-api/django-rest-framework-json-api/issues/158
+    from rest_framework.views import exception_handler as drf_exception_handler
     response = drf_exception_handler(exc, context)
 
     if not response:

--- a/rest_framework_json_api/metadata.py
+++ b/rest_framework_json_api/metadata.py
@@ -138,6 +138,7 @@ class JSONAPIMetadata(SimpleMetadata):
                 for choice_value, choice_name in field.choices.items()
             ]
 
+        #Allow includes for all Relations unless explicitly
         if hasattr(serializer, 'included_serializers') and 'relationship_resource' in field_info:
             field_info['allows_include'] = field.field_name in serializer.included_serializers
 

--- a/rest_framework_json_api/mixins.py
+++ b/rest_framework_json_api/mixins.py
@@ -19,7 +19,7 @@ class MultipleIDMixin(object):
             ids = self.request.query_params.get('filter[id]').split(',')
 
         if ids:
-            self.queryset = self.queryset.filter(id__in=ids)
+            self.queryset = self.queryset.filter(pk__in=ids)
 
         return self.queryset
 

--- a/rest_framework_json_api/parsers.py
+++ b/rest_framework_json_api/parsers.py
@@ -43,7 +43,7 @@ class JSONParser(parsers.JSONParser):
             if isinstance(field_data, dict):
                 parsed_relationships[field_name] = field_data['id']
             elif isinstance(field_data, list):
-                parsed_relationships[field_name] = list(relation for relation in field_data['id'])
+                parsed_relationships[field_name] = list(relation['id'] for relation in field_data)
         return parsed_relationships
 
     def parse(self, stream, media_type=None, parser_context=None):

--- a/rest_framework_json_api/relations.py
+++ b/rest_framework_json_api/relations.py
@@ -135,7 +135,7 @@ class ResourceRelatedField(PrimaryKeyRelatedField):
         #root = getattr(self.parent, 'parent', self.parent)
         root = self.parent
         field_name = self.field_name if self.field_name else self.parent.field_name
-        if getattr(root, 'included_serializers', None) is not None:
+        if getattr(root, 'included_serializers_override', None) is not None:
             include_overrides = get_included_serializers_override(root)
             if field_name in include_overrides.keys():
                 resource_type = get_resource_type_from_serializer(include_overrides[field_name])

--- a/rest_framework_json_api/relations.py
+++ b/rest_framework_json_api/relations.py
@@ -7,7 +7,7 @@ from django.utils.translation import ugettext_lazy as _
 from rest_framework_json_api.exceptions import Conflict
 from rest_framework_json_api.utils import Hyperlink, \
     get_resource_type_from_queryset, get_resource_type_from_instance, \
-    get_included_serializers, get_resource_type_from_serializer
+    get_included_serializers_override, get_resource_type_from_serializer
 
 
 class ResourceRelatedField(PrimaryKeyRelatedField):
@@ -108,7 +108,7 @@ class ResourceRelatedField(PrimaryKeyRelatedField):
             return_data.update({'related': related_link})
         return return_data
 
-    # def to_internal_value(self, data):
+        # def to_internal_value(self, data):
         # if isinstance(data, six.text_type):
         #     try:
         #         data = json.loads(data)
@@ -120,6 +120,7 @@ class ResourceRelatedField(PrimaryKeyRelatedField):
         # expected_relation_type = get_resource_type_from_queryset(self.queryset)
         # if data['type'] != expected_relation_type:
         #     self.conflict('incorrect_relation_type', relation_type=expected_relation_type, received_type=data['type'])
+
     #     return super(ResourceRelatedField, self).to_internal_value(data['id'])
 
     def to_representation(self, value):
@@ -135,9 +136,12 @@ class ResourceRelatedField(PrimaryKeyRelatedField):
         root = self.parent
         field_name = self.field_name if self.field_name else self.parent.field_name
         if getattr(root, 'included_serializers', None) is not None:
-            includes = get_included_serializers(root)
-            if field_name in includes.keys():
-                resource_type = get_resource_type_from_serializer(includes[field_name])
+            include_overrides = get_included_serializers_override(root)
+            if field_name in include_overrides.keys():
+                resource_type = get_resource_type_from_serializer(include_overrides[field_name])
+
+        # if included_serializers_override is defined, use that one instead of the default serializer defined on the instance model
+
 
         resource_type = resource_type if resource_type else get_resource_type_from_instance(value)
         return OrderedDict([('type', resource_type), ('id', str(pk))])
@@ -151,12 +155,12 @@ class ResourceRelatedField(PrimaryKeyRelatedField):
             return {}
 
         return OrderedDict([
-            (
-                json.dumps(self.to_representation(item)),
-                self.display_value(item)
-            )
-            for item in queryset
-        ])
+                               (
+                                   json.dumps(self.to_representation(item)),
+                                   self.display_value(item)
+                               )
+                               for item in queryset
+                               ])
 
 
 class SerializerMethodResourceRelatedField(ResourceRelatedField):

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -156,6 +156,11 @@ class JSONRenderer(renderers.JSONRenderer):
 
                 if isinstance(field.child_relation, ResourceRelatedField):
                     # special case for ResourceRelatedField
+
+                    if field_name not in resource:
+                        continue
+
+
                     relation_data = {
                         'data': resource.get(field_name)
                     }
@@ -170,7 +175,6 @@ class JSONRenderer(renderers.JSONRenderer):
                                 'meta': {
                                     'count': len(resource.get(field_name))
                                 }
-                                if resource.get(field_name) else dict()
                             }
                     )
                     data.update({field_name: relation_data})

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -170,6 +170,7 @@ class JSONRenderer(renderers.JSONRenderer):
                                 'meta': {
                                     'count': len(resource.get(field_name))
                                 }
+                                if resource.get(field_name) else dict()
                             }
                     )
                     data.update({field_name: relation_data})

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -307,7 +307,7 @@ class JSONRenderer(renderers.JSONRenderer):
 
             if isinstance(field, ModelSerializer):
 
-                relation_type = utils.get_resource_type_from_serializer(field)
+                relation_type = utils.get_resource_type_from_serializer(field.__class__)
 
                 # Get the serializer fields
                 serializer_fields = utils.get_serializer_fields(field)

--- a/rest_framework_json_api/serializers.py
+++ b/rest_framework_json_api/serializers.py
@@ -5,7 +5,7 @@ from rest_framework.serializers import *
 from rest_framework_json_api.relations import ResourceRelatedField
 from rest_framework_json_api.utils import (
     get_resource_type_from_model, get_resource_type_from_instance,
-    get_resource_type_from_serializer, get_included_serializers)
+    get_resource_type_from_serializer, get_included_configuration)
 
 
 class ResourceIdentifierObjectSerializer(BaseSerializer):
@@ -72,7 +72,7 @@ class IncludedResourcesValidationMixin(object):
         view = context.get('view') if context else None
 
         def validate_path(serializer_class, field_path, path):
-            serializers = get_included_serializers(serializer_class)
+            serializers = get_included_configuration(serializer_class)
             if serializers is None:
                 raise ParseError('This endpoint does not support the include parameter')
             this_field_name = field_path[0]

--- a/rest_framework_json_api/utils.py
+++ b/rest_framework_json_api/utils.py
@@ -240,10 +240,7 @@ def get_resource_type_from_serializer(serializer):
             None)
 
     if not resource_name:
-        if isinstance(serializer, object):
-            resource_name = format_relation_name(string.replace(serializer.__class__.__name__, 'Serializer', ''))
-        else:
-            resource_name = format_relation_name(string.replace(serializer.__name__, 'Serializer', ''))
+        resource_name = format_relation_name(string.replace(serializer.__name__, 'Serializer', ''))
         # resource_name = get_resource_type_from_model(serializer.Meta.model)
 
     return resource_name


### PR DESCRIPTION
If a queryset without an `order_by` runs multiple times and uses an offset, the returned items are not always in the same order.  This results in incorrect, missing, or duplicate data in a list view.

This PR checks to see whether the `serializer.instance` is a queryset.  If so, it matches the serializer data to the model by `pk`.  This might potentially be a breaking change if the serializer is a model serializer but does not expose the `id` field.

This PR also wraps serializer.instance as a list, so that the queryset is not evaluated many times.  In other words, `some_queryset[0]` followed by `some_queryset[1]` results in two SQL queries whereas `list(some_queryset)[0]` followed by `list(some_queryset)[1]` is only one.
