### PR TITLE
Passing relation `type` into serializers

### DIFF
--- a/rest_framework_json_api/__init__.py
+++ b/rest_framework_json_api/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 __title__ = 'djangorestframework-jsonapi'
-__version__ = '2.0.0-alpha.3'
+__version__ = '3.0.0-mt'
 __author__ = ''
 __license__ = 'MIT'
 __copyright__ = ''

--- a/rest_framework_json_api/parsers.py
+++ b/rest_framework_json_api/parsers.py
@@ -41,9 +41,9 @@ class JSONParser(parsers.JSONParser):
         for field_name, field_data in relationships.items():
             field_data = field_data.get('data', None)
             if isinstance(field_data, dict):
-                parsed_relationships[field_name] = field_data.get('id', None)
+                parsed_relationships[field_name] = field_data
             elif isinstance(field_data, list):
-                parsed_relationships[field_name] = list(relation.get('id', None) for relation in field_data)
+                parsed_relationships[field_name] = list(relation for relation in field_data)
             elif field_data == None:
                 parsed_relationships[field_name] = field_data
         return parsed_relationships

--- a/rest_framework_json_api/relations.py
+++ b/rest_framework_json_api/relations.py
@@ -162,6 +162,18 @@ class ResourceRelatedField(PrimaryKeyRelatedField):
                                for item in queryset
                                ])
 
+    def validate_empty_values(self, data):
+        if isinstance(data, dict) and 'id' in data and data['id'] is None:
+            return super(ResourceRelatedField, self).validate_empty_values(data['id'])
+
+        return super(ResourceRelatedField, self).validate_empty_values(data)
+
+    def to_internal_value(self, data):
+        if isinstance(data, dict) and 'id' in data:
+            return super(ResourceRelatedField, self).to_internal_value(data['id'])
+
+        return super(ResourceRelatedField, self).to_internal_value(data)
+
 
 class SerializerMethodResourceRelatedField(ResourceRelatedField):
     def get_attribute(self, instance):

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -11,6 +11,7 @@ from rest_framework import relations
 from rest_framework import renderers
 from rest_framework.serializers import BaseSerializer, ListSerializer, ModelSerializer
 from rest_framework.settings import api_settings
+from rest_framework.fields import get_attribute
 
 from . import utils
 
@@ -86,7 +87,7 @@ class JSONRenderer(renderers.JSONRenderer):
 
             source = field.source
             try:
-                relation_instance_or_manager = getattr(resource_instance, source)
+                relation_instance_or_manager = get_attribute(resource_instance, source.split('.'))
             except AttributeError:
                 # if the field is not defined on the model then we check the serializer
                 # and if no value is there we skip over the field completely

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -262,15 +262,15 @@ class JSONRenderer(renderers.JSONRenderer):
                 continue
 
             try:
-                relation_instance_or_manager = getattr(resource_instance, field_name)
+                relation_instance_or_manager = get_attribute(resource_instance, field.source.split('.'))
             except AttributeError:
                 try:
                     # For ManyRelatedFields if `related_name` is not set we need to access `foo_set` from `source`
-                    relation_instance_or_manager = getattr(resource_instance, field.child_relation.source)
+                    relation_instance_or_manager = get_attribute(resource_instance, field.child_relation.source.split('.'))
                 except AttributeError:
                     if not hasattr(current_serializer, field.source):
                         continue
-                    serializer_method = getattr(current_serializer, field.source)
+                    serializer_method = get_attribute(current_serializer, field.source.split('.'))
                     relation_instance_or_manager = serializer_method(resource_instance)
 
             new_included_resources = [key.replace('%s.' % field_name, '', 1)


### PR DESCRIPTION
Previously, `type` information was discarded by the parser.  This change allows the serializer to see the original relation payload (`id` and `type`)
