### PR TITLE
Do not output write_only fields

### DIFF
--- a/rest_framework_json_api/__init__.py
+++ b/rest_framework_json_api/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 __title__ = 'djangorestframework-jsonapi'
-__version__ = '3.0.2-mt'
+__version__ = '3.0.3-mt'
 __author__ = ''
 __license__ = 'MIT'
 __copyright__ = ''

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -46,6 +46,9 @@ class JSONRenderer(renderers.JSONRenderer):
             # ID is always provided in the root of JSON API so remove it from attributes
             if field_name == 'id':
                 continue
+            # don't output a key for write only fields
+            if fields[field_name].write_only:
+                continue
             # Skip fields with relations
             if isinstance(field, (relations.RelatedField, relations.ManyRelatedField, BaseSerializer)):
                 continue


### PR DESCRIPTION
Fixed in official package:
https://github.com/django-json-api/django-rest-framework-json-api/issues/230
